### PR TITLE
Require HTTPS on server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 // server.js
-const { createServer } = require("http");
+const { createServer } = require("https");
 const { parse } = require("url");
 const next = require("next");
 const fs = require("fs");


### PR DESCRIPTION
reprogle.org is requiring https in `server.js` but the source code shows http. Fixing with this pull request